### PR TITLE
Refactor: Use createResource for data fetching in GenreList and SongList

### DIFF
--- a/src/SearchUtil.ts
+++ b/src/SearchUtil.ts
@@ -437,7 +437,7 @@ async function searchSongs(
 
   const { data, error } = await builder.range(offset, offset + limit - 1)
   if (error) {
-    console.log(error)
+    console.error(error)
   }
   if (data) {
     data.forEach((song: Song) => {

--- a/src/components/GenreList.tsx
+++ b/src/components/GenreList.tsx
@@ -1,72 +1,72 @@
-import { type Component, createEffect, Index, createSignal, DEV } from 'solid-js'
+import { type Component, Index, DEV, createResource, Show } from 'solid-js'
 
 import { supabase } from './App'
 import { Style, StyleChildren } from '../model.types'
 import GenreListItem, { GenreWrapper } from './GenreListItem'
 
-
-const addChildren = (genre: GenreWrapper, genres: Style[], children: Record<number, number[]>) => {
-  for (let g of genres) {
-    if (children[genre.genre.id] && children[genre.genre.id].includes(g.id)) {
-      let wrapper = new GenreWrapper(g)
-      addChildren(wrapper, genres, children)
-      genre.children.push(wrapper)
+const fetchGenres = async () => {
+  const addChildren = (genre: GenreWrapper, genres: Style[], children: Record<number, number[]>) => {
+    for (let g of genres) {
+      if (children[genre.genre.id] && children[genre.genre.id].includes(g.id)) {
+        let wrapper = new GenreWrapper(g)
+        addChildren(wrapper, genres, children)
+        genre.children.push(wrapper)
+      }
     }
+    return genre
   }
-  return genre
+
+  let genreList: Style[] = []
+  const { data: stylesData, error: stylesError } = await supabase.from('styles').select()
+  if (stylesError) {
+    console.error(stylesError)
+    throw stylesError
+  }
+  if (stylesData) {
+    if (DEV) console.log(stylesData)
+    genreList = stylesData
+  }
+  genreList.sort((a, b) => a.name!.localeCompare(b.name!))
+
+  let children: Record<number, number[]> = {}
+  let childIds: Record<number, boolean> = {}
+  const { data: styleChildrenData, error: styleChildrenError } = await supabase.from('stylechildren').select()
+  if (styleChildrenError) {
+    console.error(styleChildrenError)
+    throw styleChildrenError
+  }
+  if (styleChildrenData) {
+    if (DEV) console.log(styleChildrenData)
+    styleChildrenData.forEach((x: StyleChildren) => {
+      if (!children[x.parentid]) children[x.parentid] = []
+      children[x.parentid].push(x.childid)
+      childIds[x.childid] = true
+    })
+  }
+
+  let parentGenres: GenreWrapper[] = genreList.filter(g => !childIds[g.id]).map(g => new GenreWrapper(g))
+  parentGenres = parentGenres.map(g => addChildren(g, genreList, children))
+  if (DEV) console.log(parentGenres)
+  return parentGenres
 }
 
-
 const GenreList: Component = () => {
-  const [genres, setGenres] = createSignal<GenreWrapper[]>([])
-  createEffect(async () => {
-    let genreList: Style[] = []
-    {
-      const { data, error } = await supabase.from('styles').select()
-      if (error) {
-        console.log(error)
-      }
-      if (data) {
-        if (DEV) console.log(data)
-        data.forEach((x) => {
-          genreList.push(x)
-        })
-      }
-    }
-    genreList.sort((a, b) => a.name!.localeCompare(b.name!))
-
-    let children: Record<number, number[]> = {}
-    let childIds: Record<number, boolean> = {}
-    {
-      const { data, error } = await supabase.from('stylechildren').select()
-      if (error) {
-        console.log(error)
-      }
-      if (data) {
-        if (DEV) console.log(data)
-        data.forEach((x: StyleChildren) => {
-          if (!children[x.parentid]) children[x.parentid] = []
-          children[x.parentid].push(x.childid)
-          childIds[x.childid] = true
-        })
-      }
-    }
-
-    let parentGenres: GenreWrapper[] = genreList.filter(g => !childIds[g.id]).map(g => new GenreWrapper(g))
-    parentGenres = parentGenres.map(g => addChildren(g, genreList, children))
-    setGenres(parentGenres)
-    if (DEV) console.log(parentGenres)
-  })
+  const [genres] = createResource<GenreWrapper[]>(fetchGenres)
 
   return (
     <div class="overflow-x-hidden overflow-y-scroll w-screen" style="height: calc(100vh - 128px);">
-      <table class="table">
-        <tbody>
-          <Index each={genres()}>
-            {genre => <GenreListItem genre={genre()} padding={0} />}
-          </Index>
-        </tbody>
-      </table>
+      <Show when={!genres.loading && !genres.error} fallback={<div>Loading genres...</div>}>
+        <Show when={genres.error}>
+          <div>Error loading genres: {genres.error.message}</div>
+        </Show>
+        <table class="table">
+          <tbody>
+            <Index each={genres()}>
+              {genre => <GenreListItem genre={genre()} padding={0} />}
+            </Index>
+          </tbody>
+        </table>
+      </Show>
     </div>
   )
 }


### PR DESCRIPTION
I refactored data fetching logic in GenreList.tsx and SongList.tsx to utilize SolidJS's createResource API, replacing the previous createEffect-based implementations.

Key changes:

- GenreList.tsx:
  - I made it fetch genre and style hierarchy using createResource.
  - I simplified state management for genre data.

- SongList.tsx:
  - I made it manage song fetching, including pagination and filtering (search query, active genre, active playlist), via createResource.
  - The resource automatically re-fetches when filter criteria or page changes.
  - I made it handle loading states and song accumulation for infinite scrolling.
  - IntersectionObserver logic is maintained for triggering pagination, now by updating currentPage which is a source for the resource.
  - Filter changes correctly reset the song list and pagination.

- Minor fixes:
  - I corrected error logging in SearchUtil.ts to use console.error.
  - I removed a duplicate onMount call in SongList.tsx.

This refactoring improves code clarity, leverages SolidJS's built-in primitives for asynchronous operations, and centralizes data fetching logic within resources.